### PR TITLE
Fixed typo in cancel dialog on add mileage expense page

### DIFF
--- a/src/app/fyle/add-edit-mileage/add-edit-mileage.page.ts
+++ b/src/app/fyle/add-edit-mileage/add-edit-mileage.page.ts
@@ -1184,7 +1184,7 @@ export class AddEditMileagePage implements OnInit {
         header: 'Unsaved Changes',
         message: 'You have unsaved changes. Are you sure, you want to abandon this expense?',
         primaryCta: {
-          text: 'DSICARD CHANGES'
+          text: 'DISCARD CHANGES'
         }
       });
 


### PR DESCRIPTION
![Screen Shot 2021-03-01 at 2 52 34 PM](https://user-images.githubusercontent.com/79460986/109477532-2474fc00-7a9e-11eb-9753-4d3b23105b0e.png)
