### PR TITLE
Showing dashboard on app startup for logged-in users

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -5,7 +5,7 @@ import { AuthGuard } from './core/guards/auth.guard';
 const routes: Routes = [
   {
     path: '',
-    redirectTo: 'auth/sign_in',
+    redirectTo: 'enterprise/my_dashboard',
     pathMatch: 'full'
   },
   {


### PR DESCRIPTION
Before it shows login screen -> org Switcher - > dashboard
Now logged-in users directly lands on dashboard