### PR TITLE
proj-message-fix: Hiding the warning message if project is not mandatory

### DIFF
--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.html
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.html
@@ -261,7 +261,7 @@
                     <div class="add-edit-expense--internal-block add-edit-expense--project-block"
                       [ngClass]="{ 'add-edit-expense--no-project' : !fg.controls.project.value}">
                       <app-fy-select-project [cacheName]="'expenseProjectCache'" [defaultValue]="true"
-                        [label]="'Project'" [mandatory]="txnFields.project_id.is_mandatory"
+                        [label]="'Project'" [mandatory]="txnFields?.project_id?.is_mandatory"
                         [recentlyUsed]="recentProjects" formControlName="project">
                       </app-fy-select-project>
                     </div>
@@ -775,7 +775,7 @@
             <ng-container *ngIf="isIndividualProjectsEnabled$|async as isIndividualProjectsEnabled">
               <ng-container *ngIf="individualProjectIds$|async as individualProjectIds">
 
-                <app-fy-alert *ngIf="txnFields.project_id && individualProjectIds.length === 0"
+                <app-fy-alert *ngIf="txnFields?.project_id?.is_mandatory && individualProjectIds.length === 0"
                   [message]="'There are no projects assigned to you, so this expense will be saved as a draft. Please contact admin for further help.'"
                   [type]="'warning'">
                 </app-fy-alert>

--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -764,21 +764,6 @@ export class AddEditExpensePage implements OnInit {
         orgSettings
       }))))
     )
-      .subscribe(({ transactionMandatoyFields, individualProjectIds, isIndividualProjectsEnabled, orgSettings }) => {
-        if (orgSettings.projects.enabled) {
-          if (isIndividualProjectsEnabled) {
-            if (transactionMandatoyFields.project && individualProjectIds.length > 0) {
-              this.fg.controls.project.setValidators(Validators.required);
-              this.fg.controls.project.updateValueAndValidity();
-            }
-          } else {
-            if (transactionMandatoyFields.project) {
-              this.fg.controls.project.setValidators(Validators.required);
-              this.fg.controls.project.updateValueAndValidity();
-            }
-          }
-        }
-      });
 
     combineLatest([
       this.isConnected$,

--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.ts
@@ -763,7 +763,7 @@ export class AddEditExpensePage implements OnInit {
         isIndividualProjectsEnabled,
         orgSettings
       }))))
-    )
+    );
 
     combineLatest([
       this.isConnected$,

--- a/src/app/fyle/add-edit-mileage/add-edit-mileage.page.html
+++ b/src/app/fyle/add-edit-mileage/add-edit-mileage.page.html
@@ -229,7 +229,7 @@
                       <div class="add-edit-mileage--internal-block add-edit-mileage--project-block"
                         [ngClass]="{'add-edit-mileage--no-project': fg.controls.project.touched && !fg.controls.project.valid}">
                         <app-fy-select-project [cacheName]="'mileageProjectCache'" [categoryIds]="projectCategoryIds"
-                          [label]="'Project'" [mandatory]="txnFields.project_id.is_mandatory" [defaultValue]="true"
+                          [label]="'Project'" [mandatory]="txnFields.project_id?.is_mandatory" [defaultValue]="true"
                           [recentlyUsed]="recentProjects" formControlName="project"></app-fy-select-project>
                       </div>
                     </ng-container>
@@ -464,7 +464,7 @@
                 <ng-container *ngIf="isIndividualProjectsEnabled$|async as isIndividualProjectsEnabled">
                   <ng-container *ngIf="individualProjectIds$|async as individualProjectIds">
 
-                    <app-fy-alert *ngIf="txnFields.project_id && individualProjectIds.length === 0"
+                    <app-fy-alert *ngIf="txnFields?.project_id?.is_mandatory && individualProjectIds.length === 0"
                       [type]="'warning'"
                       [message]="'There are no projects assigned to you, so this expense will be saved as a draft. Please contact admin for further help.'">
                     </app-fy-alert>

--- a/src/app/fyle/add-edit-mileage/add-edit-mileage.page.ts
+++ b/src/app/fyle/add-edit-mileage/add-edit-mileage.page.ts
@@ -96,8 +96,6 @@ export class AddEditMileagePage implements OnInit {
 
   filteredCategories$: Observable<any>;
 
-  transactionMandatoyFields$: Observable<any>;
-
   etxn$: Observable<any>;
 
   isIndividualProjectsEnabled$: Observable<boolean>;
@@ -956,42 +954,6 @@ export class AddEditMileagePage implements OnInit {
     );
 
     this.customInputs$ = this.getCustomInputs();
-
-    this.transactionMandatoyFields$ = this.isConnected$.pipe(
-      filter(isConnected => !!isConnected),
-      switchMap(() => this.offlineService.getOrgSettings()),
-      map(orgSettings => orgSettings.transaction_fields_settings.transaction_mandatory_fields || {})
-    );
-
-    this.transactionMandatoyFields$
-      .pipe(
-        filter(transactionMandatoyFields => !isEqual(transactionMandatoyFields, {})),
-        switchMap((transactionMandatoyFields) => forkJoin({
-          individualProjectIds: this.individualProjectIds$,
-          isIndividualProjectsEnabled: this.isIndividualProjectsEnabled$,
-          orgSettings: this.offlineService.getOrgSettings()
-        }).pipe(map(({ individualProjectIds, isIndividualProjectsEnabled, orgSettings }) => ({
-          transactionMandatoyFields,
-          individualProjectIds,
-          isIndividualProjectsEnabled,
-          orgSettings
-        }))))
-      )
-      .subscribe(({ transactionMandatoyFields, individualProjectIds, isIndividualProjectsEnabled, orgSettings }) => {
-        if (orgSettings.projects.enabled) {
-          if (isIndividualProjectsEnabled) {
-            if (transactionMandatoyFields.project && individualProjectIds.length > 0) {
-              this.fg.controls.project.setValidators(Validators.required);
-              this.fg.controls.project.updateValueAndValidity();
-            }
-          } else {
-            if (transactionMandatoyFields.project) {
-              this.fg.controls.project.setValidators(Validators.required);
-              this.fg.controls.project.updateValueAndValidity();
-            }
-          }
-        }
-      });
 
     this.costCenters$ = forkJoin({
       orgSettings: orgSettings$,

--- a/src/app/fyle/add-edit-per-diem/add-edit-per-diem.page.html
+++ b/src/app/fyle/add-edit-per-diem/add-edit-per-diem.page.html
@@ -464,7 +464,7 @@
                         <ng-container *ngIf="isIndividualProjectsEnabled$|async as isIndividualProjectsEnabled">
                           <ng-container *ngIf="individualProjectIds$|async as individualProjectIds">
 
-                            <app-fy-alert *ngIf="txnFields?.project_id && individualProjectIds.length === 0"
+                            <app-fy-alert *ngIf="txnFields?.project_id?.is_mandatory && individualProjectIds.length === 0"
                               [message]="'There are no projects assigned to you, so this expense will be saved as a draft. Please contact admin for further help.'"
                               [type]="'warning'">
                             </app-fy-alert>

--- a/src/app/fyle/add-edit-per-diem/add-edit-per-diem.page.ts
+++ b/src/app/fyle/add-edit-per-diem/add-edit-per-diem.page.ts
@@ -98,8 +98,6 @@ export class AddEditPerDiemPage implements OnInit {
 
   etxn$: Observable<any>;
 
-  transactionMandatoyFields$: Observable<any>;
-
   isIndividualProjectsEnabled$: Observable<boolean>;
 
   individualProjectIds$: Observable<[]>;
@@ -844,12 +842,6 @@ export class AddEditPerDiemPage implements OnInit {
       )
     );
 
-    this.transactionMandatoyFields$ = this.isConnected$.pipe(
-      filter(isConnected => !!isConnected),
-      switchMap(() => this.offlineService.getOrgSettings()),
-      map(orgSettings => orgSettings.transaction_fields_settings.transaction_mandatory_fields || {})
-    );
-
     this.isIndividualProjectsEnabled$ = orgSettings$.pipe(
       map(orgSettings => orgSettings.advanced_projects && orgSettings.advanced_projects.enable_individual_projects)
     );
@@ -857,37 +849,6 @@ export class AddEditPerDiemPage implements OnInit {
     this.individualProjectIds$ = orgUserSettings$.pipe(
       map((orgUserSettings: any) => orgUserSettings.project_ids || [])
     );
-
-    this.transactionMandatoyFields$
-      .pipe(
-        filter(transactionMandatoyFields => !isEqual(transactionMandatoyFields, {})),
-        switchMap((transactionMandatoyFields) => forkJoin({
-          individualProjectIds: this.individualProjectIds$,
-          isIndividualProjectsEnabled: this.isIndividualProjectsEnabled$,
-          orgSettings: this.offlineService.getOrgSettings()
-        }).pipe(map(({ individualProjectIds, isIndividualProjectsEnabled, orgSettings }) => ({
-          transactionMandatoyFields,
-          individualProjectIds,
-          isIndividualProjectsEnabled,
-          orgSettings
-        }))))
-      )
-      .subscribe(({ transactionMandatoyFields, individualProjectIds, isIndividualProjectsEnabled, orgSettings }) => {
-        if (orgSettings.projects.enabled) {
-          if (isIndividualProjectsEnabled) {
-            if (transactionMandatoyFields.project && individualProjectIds.length > 0) {
-              this.fg.controls.project.setValidators(Validators.required);
-              this.fg.controls.project.updateValueAndValidity();
-            }
-          } else {
-            if (transactionMandatoyFields.project) {
-              this.fg.controls.project.setValidators(Validators.required);
-              this.fg.controls.project.updateValueAndValidity();
-            }
-          }
-        }
-      });
-
 
     this.etxn$ = iif(() => this.mode === 'add', this.getNewExpense(), this.getEditExpense());
 


### PR DESCRIPTION
Case:
- enable_individual_projects setting is true
- no projects set for the employee
- project is not mandatory

The message shows `There are no projects assigned to you, the expense will go to draft`
This should be shown only if the project is mandatory