### PR TITLE
FYLE-6f6u77: Fix for split expense issue with from and to date

### DIFF
--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.html
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.html
@@ -723,13 +723,15 @@
         </ng-template>
       </div>
 
-      <div class="add-edit-expense--split-expense-block" *ngIf="(isSplitExpenseAllowed$|async) && !(reviewList && reviewList.length > 1)">
-        <button class="add-edit-expense--split-expense-container" (click)="splitExpense()">
-          <div class="add-edit-expense--split-expense-title">Split Expense</div>
-        </button>
-        <div class="add-edit-expense--split-info-container">
-          <mat-icon class="add-edit-expense--split-info-icon" svgIcon="fy-info"></mat-icon>
-          <div class="add-edit-expense--split-info-message">Fill all the required fields before splitting an expense.</div>
+      <div *ngIf="etxn$|async as etxn">
+        <div class="add-edit-expense--split-expense-block" *ngIf="(isConnected$|async) && !(etxn?.tx?.report_id) && (isSplitExpenseAllowed$|async) && !(reviewList && reviewList.length > 1)">
+          <button class="add-edit-expense--split-expense-container" (click)="splitExpense()">
+            <div class="add-edit-expense--split-expense-title">Split Expense</div>
+          </button>
+          <div class="add-edit-expense--split-info-container">
+            <mat-icon class="add-edit-expense--split-info-icon" svgIcon="fy-info"></mat-icon>
+            <div class="add-edit-expense--split-info-message">Fill all the required fields before splitting an expense.</div>
+          </div>
         </div>
       </div>
 

--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.scss
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.scss
@@ -279,6 +279,7 @@
     display: flex;
     flex-direction: row;
     background-color: $pure-white;
+    padding: 0;
   }
 
   &--split-expense-title {

--- a/src/app/fyle/split-expense/split-expense.page.ts
+++ b/src/app/fyle/split-expense/split-expense.page.ts
@@ -151,6 +151,10 @@ export class SplitExpensePage implements OnInit {
   }
 
   generateSplitEtxnFromFg(splitExpenseValue) {
+    // Fixing the date format here as the transaction object date is a string
+    this.transaction.from_dt = this.transaction?.from_dt && this.dateService.getUTCDate(new Date(this.transaction.from_dt));
+    this.transaction.to_dt = this.transaction?.to_dt && this.dateService.getUTCDate(new Date(this.transaction.to_dt));
+
     return {
       ...this.transaction,
       org_category_id: splitExpenseValue.category && splitExpenseValue.category.id,


### PR DESCRIPTION
**Issue:**
- The transaction object is set using - `this.transaction = JSON.parse(this.activatedRoute.snapshot.params.txn);` 
- This has the date formats in the form of a string, due to which, if there are mandatory category dependent date fields such from date / to date, the system throws an error blocking split expense

**Fix:**
- To fix this, explicitly converting the date while saving the split expense
- Affected user on hulk - `usb6ejcefime@fyleinbrodart.com` / anyone from Brodart using `Travel / Hotel & Tax` category

**Other fixes:**
- Restricting users to split an already reported expense
- Restricting users to split in offline mode
- Minor spacing fix added for split expense button in the expense form