### PR TITLE
Add checkbox to shimmers in multiselect mode

### DIFF
--- a/src/app/fyle/my-expenses/my-expenses.page.html
+++ b/src/app/fyle/my-expenses/my-expenses.page.html
@@ -74,7 +74,7 @@
     </div>
   </ng-container>
 
-  <app-fy-loading-screen *ngIf="isLoading" class="my-expenses--shimmers"></app-fy-loading-screen>
+  <app-fy-loading-screen *ngIf="isLoading" [isSelectionModeEnabled]="selectionMode" class="my-expenses--shimmers"></app-fy-loading-screen>
 
   <div *ngIf="(pendingTransactions.length === 0) && ((count$ | async) === 0) && isConnected$|async" class="my-expenses--zero-state">
     <img alt="Create First Expenses" class="my-expenses--zero-state-img"

--- a/src/app/shared/components/expenses-card/expenses-card.component.scss
+++ b/src/app/shared/components/expenses-card/expenses-card.component.scss
@@ -78,8 +78,8 @@
     border-radius: 8px;
     max-height: 74px;
     min-height: 74px;
-    max-width: 54px;
-    min-width: 54px;
+    max-width: 72px;
+    min-width: 72px;
     padding: 20px;
     display: flex;
     justify-content: center;

--- a/src/app/shared/components/fy-loading-screen/fy-loading-screen.component.html
+++ b/src/app/shared/components/fy-loading-screen/fy-loading-screen.component.html
@@ -1,14 +1,19 @@
 <ion-grid class="loading-screen-container" *ngFor="let row of rows">
   <ion-row>
+    <ion-col *ngIf="isSelectionModeEnabled" size="1.32">
+      <div class="loading-screen-container--checkbox">
+        <ion-skeleton-text animated></ion-skeleton-text>
+      </div>
+    </ion-col>
     <ion-col size="2.65">
       <div class="loading-screen-container--icon">
         <ion-skeleton-text animated></ion-skeleton-text>
       </div>
     </ion-col>
-    <ion-col size="6">
-      <ion-skeleton-text animated class="loading-screen-container--content-header"></ion-skeleton-text>
-      <ion-skeleton-text animated class="loading-screen-container--content-sub-header"></ion-skeleton-text>
-      <ion-skeleton-text animated class="loading-screen-container--content-sub-header"></ion-skeleton-text>
+    <ion-col [attr.size]="isSelectionModeEnabled ? 4.68 : 6" class="loading-screen-container--content-block">
+      <ion-skeleton-text animated class="loading-screen-container--content-block__header"></ion-skeleton-text>
+      <ion-skeleton-text animated class="loading-screen-container--content-block__sub-header"></ion-skeleton-text>
+      <ion-skeleton-text animated class="loading-screen-container--content-block__sub-header"></ion-skeleton-text>
     </ion-col>
     <ion-col size="3.35">
       <div class="loading-screen-container--state">

--- a/src/app/shared/components/fy-loading-screen/fy-loading-screen.component.scss
+++ b/src/app/shared/components/fy-loading-screen/fy-loading-screen.component.scss
@@ -1,26 +1,37 @@
 .loading-screen-container {
-  margin: 0 16px;
-  padding: 16px 0;
+  padding: 16px;
   border-bottom: 1px solid #DFDFE2;
+
+  &--checkbox {
+    position: absolute;
+    top: 30%;
+    height: 20px;
+    width: 20px;
+    border-radius: 6px;
+  }
 
   &--icon {
     height: 74px;
-    max-width: 72px;
+    width: 72px;
     border-radius: 8px;
   }
 
-  &--content-header {
-    height: 18px;
-    border-radius: 2px;
-    margin: 4px 12px 20px 0;
-    width: 90%;
-  }
+  &--content-block {
+    padding: 3px 23px 4px 11px;
 
-  &--content-sub-header {
-    height: 10px;
-    border-radius: 2px;
-    width: 75%;
-    margin: 6px 0;
+    &__header {
+      height: 18px;
+      border-radius: 2px;
+      margin: 4px 12px 20px 0;
+      width: 90%;
+    }
+
+    &__sub-header {
+      height: 10px;
+      border-radius: 2px;
+      width: 75%;
+      margin: 6px 0;
+    }
   }
 
   &--state {
@@ -28,4 +39,8 @@
     border-radius: 2px;
     margin-left: 24px;
   }
+}
+
+ion-col {
+  padding: 0;
 }

--- a/src/app/shared/components/fy-loading-screen/fy-loading-screen.component.ts
+++ b/src/app/shared/components/fy-loading-screen/fy-loading-screen.component.ts
@@ -6,6 +6,8 @@ import { Component, OnInit, Input } from '@angular/core';
   styleUrls: ['./fy-loading-screen.component.scss'],
 })
 export class FyLoadingScreenComponent implements OnInit {
+  @Input() isSelectionModeEnabled: boolean;
+
   rows = [1, 2, 3, 4, 5];
 
   constructor() { }


### PR DESCRIPTION
Before:
![localhost_8100_enterprise_my_dashboard(iPhone X)](https://user-images.githubusercontent.com/39493102/130394230-18bb5cee-7058-4f00-98b4-db7f02585170.png)


After:
Without multiselect:
![localhost_8100_enterprise_my_expenses_filters=%7B%7D(iPhone X) (1)](https://user-images.githubusercontent.com/39493102/130393781-cc8ffcb3-4d9d-499e-bf9e-4622cda73cb6.png)

With multiselect:
![localhost_8100_enterprise_my_expenses_filters=%7B%7D(iPhone X)](https://user-images.githubusercontent.com/39493102/130393773-701aadc3-5079-44a3-a676-95ed40f3bb3d.png)

