### PR TITLE
Align currency and amount in add expense and make boolean non-mandatory in advances page

### DIFF
--- a/src/app/fyle/add-edit-advance-request/add-edit-advance-request.page.ts
+++ b/src/app/fyle/add-edit-advance-request/add-edit-advance-request.page.ts
@@ -579,8 +579,9 @@ export class AddEditAdvanceRequestPage implements OnInit {
               value = customFieldValue.value;
             }
           });
-          if(customField.type === 'BOOLEAN') {
+          if (customField.type === 'BOOLEAN') {
             customField.mandatory = false;
+            value = false;
           }
           customFieldsFormArray.push(
             this.formBuilder.group({

--- a/src/app/fyle/add-edit-advance-request/add-edit-advance-request.page.ts
+++ b/src/app/fyle/add-edit-advance-request/add-edit-advance-request.page.ts
@@ -579,6 +579,9 @@ export class AddEditAdvanceRequestPage implements OnInit {
               value = customFieldValue.value;
             }
           });
+          if(customField.type === 'BOOLEAN') {
+            customField.mandatory = false;
+          }
           customFieldsFormArray.push(
             this.formBuilder.group({
               id: customField.id,

--- a/src/app/fyle/add-edit-expense/fy-currency/fy-currency.component.scss
+++ b/src/app/fyle/add-edit-expense/fy-currency/fy-currency.component.scss
@@ -18,6 +18,7 @@
     border: none;
     width: 100%;
     margin: 6px 0;
+    padding-left: 0;
   }
 
   &--input-invalid {
@@ -43,6 +44,7 @@
 
   &--amount {
     font-size: 20px;
+    line-height: 1.2;
     font-weight: 500;
     margin-top: 0;
   }


### PR DESCRIPTION
Align currency and amount in add expenses:
Before:
![localhost_8100_enterprise_add_edit_expense;id=txwhqUkcXWf6;persist_filters=true(Moto G4)](https://user-images.githubusercontent.com/39493102/131671727-876fb75f-e53b-4700-bc3c-7be50be18079.png)

After without invalid input error
![localhost_8100_enterprise_add_edit_expense;navigate_back=true(Moto G4) (7)](https://user-images.githubusercontent.com/39493102/131671738-52f32063-989f-423c-9a78-db35fa73667b.png)

After with invalid input error
![localhost_8100_enterprise_add_edit_expense;navigate_back=true(Moto G4) (6)](https://user-images.githubusercontent.com/39493102/131671743-76db6f3b-57f2-45e1-a8f0-f52f20d8a98e.png)


Make boolean non-mandatory in advances page:
Before:
https://user-images.githubusercontent.com/39493102/131671751-34bfda02-8fc2-4827-95a5-da572317d9d8.mp4

After:
https://user-images.githubusercontent.com/39493102/131671764-e67f315e-8d30-452c-bf20-d4c97d144b41.mp4