### PR TITLE
Fix minor bugs

### DIFF
--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.html
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.html
@@ -65,7 +65,7 @@
 
     <form #formContainer [formGroup]="fg" class="add-edit-expense--form">
       <div>
-        <div *ngIf="instaFyleCancelled">
+        <div *ngIf="instaFyleCancelled" class="add-edit-expense--alert-offline">
           <app-fy-alert-info [message]="'Extracting receipt details is taking longer than expected due to a bad network, please add the details
             manually'" [type]="'information'">
           </app-fy-alert-info>

--- a/src/app/fyle/add-edit-expense/add-edit-expense.page.scss
+++ b/src/app/fyle/add-edit-expense/add-edit-expense.page.scss
@@ -187,6 +187,10 @@
     padding: 0 16px;
   }
 
+  &--alert-offline {
+    padding-top: 10px;
+  }
+
   &--date {
     border-bottom: 1px solid $grey-lighter;
   }

--- a/src/app/fyle/capture-receipt/add-more-popup/add-more-popup.component.scss
+++ b/src/app/fyle/capture-receipt/add-more-popup/add-more-popup.component.scss
@@ -20,6 +20,10 @@
     &__camera {
       stroke: $grey-light;
     }
+
+    &__gallery {
+      color: $grey-light;
+    }
   }
 
   &--divider {

--- a/src/app/fyle/team-reports/team-reports.page.scss
+++ b/src/app/fyle/team-reports/team-reports.page.scss
@@ -77,6 +77,7 @@ $toolbar-border: #ababab6b;
 
   &--content {
     --background: #{$white};
+    --padding-bottom: 82px;
   }
 
   &--zero-state {


### PR DESCRIPTION
Info alert box top padding in offline mode
Before:
![Screenshot_20210908-140754](https://user-images.githubusercontent.com/39493102/132652104-cdb98615-4a98-4f68-8869-2cc7ab6e33d9.jpg)

After:
![localhost_8100_(iPhone 6_7_8 Plus)](https://user-images.githubusercontent.com/39493102/132651729-b7881a6a-47bc-4757-afd1-5ac5cb3fdff5.png)


Team reports add padding to last report
Before:
![Screenshot_20210908-144248](https://user-images.githubusercontent.com/39493102/132652166-d6130fe8-d229-463b-a5e4-c7e122602c88.jpg)


After:
![localhost_8100_enterprise_team_reports_filters=%7B%7D(iPhone 6_7_8 Plus) (3)](https://user-images.githubusercontent.com/39493102/132651805-86e49209-857a-42bc-9a1c-771e1a24be08.png)


Gallery icon color in receipt preview:
Before:
![localhost_8100_(iPhone 6_7_8 Plus) (1)](https://user-images.githubusercontent.com/39493102/132651673-a6b0d65b-f197-458f-ac04-3b19eded4e43.png)

After:
![localhost_8100_enterprise_camera_overlay;navigate_back=true(iPhone 6_7_8 Plus)](https://user-images.githubusercontent.com/39493102/132651688-2cfeae0d-bc50-405f-9729-b40b4c0f7167.png)
