### PR TITLE
Fix for black bg in personal cards on iOS

### DIFF
--- a/src/app/fyle/personal-cards/personal-cards.page.scss
+++ b/src/app/fyle/personal-cards/personal-cards.page.scss
@@ -259,6 +259,7 @@
     padding: 5px 14px;
     justify-content: flex-end;
     z-index: 1000;
+    background-color: $pure-white;
 
     &__left {
       margin-right: auto;

--- a/src/app/shared/components/bank-account-cards/bank-account-cards.component.scss
+++ b/src/app/shared/components/bank-account-cards/bank-account-cards.component.scss
@@ -1,6 +1,10 @@
+@import '../../../../theme/colors.scss';
+
 .bank-accounts {
   padding: 12px 0;
   height: 140px;
+  background-color: $pure-white;
+
   &--swiper {
     height: 136px;
   }


### PR DESCRIPTION
![image0 (5)](https://user-images.githubusercontent.com/31147415/144187747-22e8163a-94bb-49db-860e-e153e05ea8c5.png)
