### PR TITLE
Remove duplicate color and fix background in profile page

### DIFF
--- a/src/app/fyle/my-profile/my-profile.page.html
+++ b/src/app/fyle/my-profile/my-profile.page.html
@@ -7,11 +7,11 @@
   </ion-toolbar>
 </ion-header>
 
-<ion-content>
+<ion-content class="my-profile__content-container">
   <ng-container *ngIf="eou$ | async as eou">
     <app-employee-details-card [eou]="eou"></app-employee-details-card>
   </ng-container>
-  <div class="my-profile__content-container">
+  <div class="my-profile__content-container__content">
     <div class="my-profile__section-header">Notifications</div>
     <div class="my-profile__card" [routerLink]="[ '/', 'enterprise', 'notifications' ]" matRipple>
       <div class="my-profile__card__title">Manage Notifications</div>

--- a/src/app/fyle/my-profile/my-profile.page.scss
+++ b/src/app/fyle/my-profile/my-profile.page.scss
@@ -10,8 +10,11 @@
   }
 
   &__content-container {
-    background-color: $grey-8;
-    padding: 24px 16px;
+    --background: #{$off-white};
+
+    &__content {
+      padding: 24px 16px;
+    }
   }
 
   &__section-header {

--- a/src/theme/colors.scss
+++ b/src/theme/colors.scss
@@ -13,7 +13,6 @@ $grey-4: #f9f9f9;
 $grey-5: #e5e5e5;
 $grey-6: #e0e0e0 !default;
 $grey-7: #eeeeee !default;
-$grey-8: #f5f5f5 !default;
 $grey-light: #a9acbc !default;
 $grey-light-2: #4a4a4a !default;
 $grey-lighter: #dfdfe2 !default;


### PR DESCRIPTION
Issue: The background color was not applied on the entire page so it defaults to white when content is small.

Before: 
![Screenshot_20211206-010101](https://user-images.githubusercontent.com/39493102/144845113-42805c24-55a6-46ab-8c35-aaa5168b6991.jpg)


After:
![localhost_8100_enterprise_my_profile(iPhone 6_7_8 Plus)](https://user-images.githubusercontent.com/39493102/144845209-29618b59-1292-4659-97c2-a4d80ea72ef0.png)